### PR TITLE
Bugfix/error reading password env 35

### DIFF
--- a/apps/pages/results/result.py
+++ b/apps/pages/results/result.py
@@ -26,7 +26,11 @@ ENV_CONFIG = {}
 for key, value in dotenv_values().items():
     ENV_CONFIG[key] = value
 
-with open(os.getcwd() + "\\apps\\pages\\results\\password.env") as f:
+# Construct the file path using os.path.join for cross-platform compatibility
+file_path = os.path.join(os.getcwd(), "apps", "pages", "results", "password.env")
+
+# Open the file and read the password
+with open(file_path, 'r') as f:
     password = f.read().split('=')[1]
 
 dash.register_page(__name__, path_template='/result/<result_id>')


### PR DESCRIPTION
## **Description**
There was an error in the file apps/pages/results/results.py when attempting to read from the password.env file. The specific line of code causing the issue was:

```py
with open(os.getcwd() + "\\apps\\pages\\results\\password.env") as f:
    password = f.read().split('=')[1]
```
This fix resolves the hardcoded file path and potential issues with file accessibility or format.

## **Changes**
1. Fixed the error in apps/pages/results/results.py by updating the file path handling for password.env.

## **Desktop**
OS: Windows
Version: 11

## **Related Issues**

Closes [#35](https://github.com/tahiri-lab/iPhyloGeo/issues/35)

## Additional context
Consider adding a .gitignore file to exclude the ./scripts/results/ folder from being tracked. Additionally, update the documentation to instruct developers to add this folder to their local .gitignore to prevent accidental tracking of output files.