### PR TITLE
fix the error apparition bug

### DIFF
--- a/apps/pages/getStarted.py
+++ b/apps/pages/getStarted.py
@@ -714,7 +714,7 @@ def parse_uploaded_files(content, file_name):
 def ready_for_pipeline(open, result_name, input_data, params_climatic):
     """
     Verify the following prerequisites needed for aPhyloGeo pipeline to start:
-     - At least two columns are selected from the climatic data file.
+    - At least one column is selected from the climatic data file.
      - The dataset has a name.
      - Verify the presence of uploaded climatic and genetic data.
 
@@ -758,7 +758,7 @@ def ready_for_pipeline(open, result_name, input_data, params_climatic):
         params_climatic["names"] is not None and len(params_climatic["names"]) >= 2
     )
 
-    # Assure that at least two columns from the climatic data are selected
+    # Assure that at least one climatic column is selected
     if (
         climatic_data_is_present and not params_climatic_is_complete and result_name_is_valid
     ):
@@ -794,8 +794,8 @@ def ready_for_pipeline(open, result_name, input_data, params_climatic):
     prevent_initial_call=True,
 )
 def clear_column_error_when_valid(column_names):
-    """Clear the column error as soon as at least two columns are selected."""
-    if column_names is not None and len(column_names) >= 2:
+    """Clear the column error as soon as at least one column is selected."""
+    if column_names is not None and len(column_names) >= 1:
         return ""
     return dash.no_update
 


### PR DESCRIPTION
This pull request updates the validation logic for selecting columns from the climatic data file in the aPhyloGeo pipeline setup. The main change is reducing the minimum required number of selected columns from two to one, affecting both the user interface and backend validation.

Validation logic updates:

* The prerequisite for running the pipeline now requires at least one column to be selected from the climatic data file instead of two, updating both documentation and logic in `ready_for_pipeline` (`apps/pages/getStarted.py`). [[1]](diffhunk://#diff-3a2c7bbe2bc061f8e78dcac5e334e441bd6f69589985b00bf9314bae427757f5L717-R717) [[2]](diffhunk://#diff-3a2c7bbe2bc061f8e78dcac5e334e441bd6f69589985b00bf9314bae427757f5L761-R761)
* The error-clearing logic for column selection is updated to clear the error when at least one column is selected, rather than two, in the `clear_column_error_when_valid` function (`apps/pages/getStarted.py`).