### PR TITLE
adding separate table for the result and the statistical test

### DIFF
--- a/apps/assets/styles/result.scss
+++ b/apps/assets/styles/result.scss
@@ -1,4 +1,4 @@
-@use 'utils/table';
+@use "utils/table";
 
 .resultContainer {
   width: 100%;
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: column;
 
-  >.title {
+  > .title {
     color: var(--text);
     font-size: 36px;
     font-weight: bold;
@@ -113,7 +113,9 @@
   max-height: 0 !important;
   overflow: hidden !important;
   margin-top: 0 !important;
-  transition: opacity 0.3s ease-in-out, max-height 0.6s ease-in-out !important;
+  transition:
+    opacity 0.3s ease-in-out,
+    max-height 0.6s ease-in-out !important;
 }
 
 // Collapsible Areas
@@ -121,9 +123,19 @@
   opacity: 1;
   overflow: visible;
   max-height: 10000px;
-  transition: opacity 0.3s ease-in-out, max-height 0.6s ease-in-out;
+  transition:
+    opacity 0.3s ease-in-out,
+    max-height 0.6s ease-in-out;
   width: 100%;
   box-sizing: border-box;
+
+  .results-table-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--text);
+    margin-bottom: 12px;
+    text-align: left;
+  }
 
   .graph {
     margin-top: 20px;
@@ -138,7 +150,9 @@
   width: 100%;
   max-height: 10000px;
   opacity: 1;
-  transition: opacity 1s ease-in-out, max-height 0s ease-in-out;
+  transition:
+    opacity 1s ease-in-out,
+    max-height 0s ease-in-out;
   box-sizing: border-box;
 
   .tree-sub-container {
@@ -176,11 +190,12 @@
   }
 }
 
-
 // Email section
 #email-section-container {
   max-height: 500px;
   opacity: 1;
-  transition: opacity 0.3s ease-in-out, max-height 0.3s ease-in-out;
+  transition:
+    opacity 0.3s ease-in-out,
+    max-height 0.3s ease-in-out;
   margin-top: 16px;
 }

--- a/apps/locales/en/result.json
+++ b/apps/locales/en/result.json
@@ -23,7 +23,9 @@
     "error": "Error sending email"
   },
   "table": {
-    "filter-placeholder": "Filter data..."
+    "filter-placeholder": "Filter data...",
+    "main-results-title": "Main Results",
+    "statistical-tests-title": "Statistical Tests"
   },
   "email-template": {
     "subject": "Your iPhyloGeo results are ready!",

--- a/apps/locales/fr/result.json
+++ b/apps/locales/fr/result.json
@@ -23,7 +23,9 @@
     "error": "Erreur lors de l'envoi de l'e-mail"
   },
   "table": {
-    "filter-placeholder": "Filtrer les données..."
+    "filter-placeholder": "Filtrer les données...",
+    "main-results-title": "Résultats principaux",
+    "statistical-tests-title": "Tests statistiques"
   },
   "email-template": {
     "subject": "Vos résultats iPhyloGeo sont prêts !",

--- a/apps/pages/results/result.py
+++ b/apps/pages/results/result.py
@@ -530,36 +530,6 @@ def create_result_table_header(lang="en"):
     )
 
 
-def create_result_table(data, lang="en"):
-    """
-    This function creates the results table
-    args:
-        data (pandas.DataFrame): the data to display in the table
-    returns:
-        dash_table.DataTable: the table containing the results
-    """
-
-    return html.Div(
-        [
-            dash_table.DataTable(
-                id="datatable-interactivity",
-                data=data.to_dict("records"),
-                columns=[{"name": i, "id": i} for i in data.columns],
-                filter_action="native",
-                sort_action="native",
-                sort_mode="single",
-                page_current=0,
-                page_size=15,
-                filter_query="",
-                filter_options={"placeholder_text": t("result.table.filter-placeholder", lang)},
-                row_selectable="multi",
-                **utils.get_table_styles(),
-            )
-        ],
-        className="shared-table",
-    )
-
-
 def create_titled_result_table(data, title, table_id, lang="en"):
     return html.Div(
         [
@@ -588,11 +558,15 @@ def create_titled_result_table(data, title, table_id, lang="en"):
 
 
 def split_output_tables(results_data):
-    if not isinstance(results_data, pd.DataFrame) or results_data.empty:
-        return results_data, pd.DataFrame(columns=getattr(results_data, "columns", []))
+    expected_order = ["Mantel_r", "Mantel_p", "Procrustes_M2", "PROTEST_p"]
+
+    if not isinstance(results_data, pd.DataFrame):
+        return pd.DataFrame(), pd.DataFrame(columns=expected_order)
+
+    if results_data.empty:
+        return results_data, pd.DataFrame(columns=expected_order)
 
     df = results_data.reset_index(drop=True).copy()
-    expected_order = ["Mantel_r", "Mantel_p", "Procrustes_M2", "PROTEST_p"]
 
     def normalize_token(token):
         return re.sub(r"[^a-z0-9]", "", str(token).lower())

--- a/apps/pages/results/result.py
+++ b/apps/pages/results/result.py
@@ -123,7 +123,8 @@ layout = html.Div(
                         html.Div(id="results-table-title"),
                         html.Div(
                             [
-                                html.Div(id="output-results"),
+                                html.Div(id="main-results-table-container"),
+                                html.Div(id="statistical-results-table-container"),
                                 html.Div(id="output-results-graph", className="graph"),
                             ],
                             id="results-row",
@@ -251,7 +252,8 @@ def update_result_static_text(language):
 
 @callback(
     Output("results-table-title", "children"),
-    Output("output-results", "children"),
+    Output("main-results-table-container", "children"),
+    Output("statistical-results-table-container", "children"),
     Output("output-results-graph", "children"),
     State("url", "pathname"),
     Input("all-results", "children"),
@@ -279,7 +281,7 @@ def show_complete_results(path, generated_page, language):
     result = utils.get_result(result_id)
 
     if "genetic" not in result["result_type"] or "output" not in result:
-        return "", "", ""
+        return "", "", "", ""
 
     results_data = str_csv_to_df(result["output"])
 
@@ -289,21 +291,45 @@ def show_complete_results(path, generated_page, language):
     ):
         return (
             create_result_table_header(lang),  # Still return the header
-            create_result_table(results_data, lang),  # Display the table (might be empty)
+            create_titled_result_table(
+                results_data,
+                t("result.table.main-results-title", lang),
+                "datatable-main-results",
+                lang,
+            ),
+            "",  # No statistical table to display
             "",  # No graph to display
         )
 
-    # Filter out statistical test summary rows (NaN in core columns) for the graphic
+    # Split exported output into main results and optional statistical test block
     core_cols = ["Position in ASM", "Bootstrap mean"]
     results_data[core_cols] = results_data[core_cols].replace(r'^\s*$', np.nan, regex=True)
-    graphic_data = results_data.dropna(subset=core_cols)
+    normal_results_data, statistical_results_data = split_output_tables(results_data)
+    graphic_data = normal_results_data.dropna(subset=core_cols)
 
     # Now it's safe to call create_result_graphic
     graph_output = create_result_graphic(graphic_data, lang) if len(graphic_data) > 0 else None
 
+    main_results_table = create_titled_result_table(
+        normal_results_data,
+        t("result.table.main-results-title", lang),
+        "datatable-main-results",
+        lang,
+    )
+
+    statistical_results_table = ""
+    if isinstance(statistical_results_data, pd.DataFrame) and not statistical_results_data.empty:
+        statistical_results_table = create_titled_result_table(
+            statistical_results_data,
+            t("result.table.statistical-tests-title", lang),
+            "datatable-statistical-tests",
+            lang,
+        )
+
     return (
         create_result_table_header(lang),
-        create_result_table(results_data, lang),
+        main_results_table,
+        statistical_results_table,
         graph_output,
     )
 
@@ -532,6 +558,89 @@ def create_result_table(data, lang="en"):
         ],
         className="shared-table",
     )
+
+
+def create_titled_result_table(data, title, table_id, lang="en"):
+    return html.Div(
+        [
+            html.Div(title, className="results-table-title"),
+            html.Div(
+                [
+                    dash_table.DataTable(
+                        id=table_id,
+                        data=data.to_dict("records"),
+                        columns=[{"name": i, "id": i} for i in data.columns],
+                        filter_action="native",
+                        sort_action="native",
+                        sort_mode="single",
+                        page_current=0,
+                        page_size=15,
+                        filter_query="",
+                        filter_options={"placeholder_text": t("result.table.filter-placeholder", lang)},
+                        row_selectable="multi",
+                        **utils.get_table_styles(),
+                    ),
+                ],
+                className="shared-table",
+            ),
+        ]
+    )
+
+
+def split_output_tables(results_data):
+    if not isinstance(results_data, pd.DataFrame) or results_data.empty:
+        return results_data, pd.DataFrame(columns=getattr(results_data, "columns", []))
+
+    df = results_data.reset_index(drop=True).copy()
+    expected_order = ["Mantel_r", "Mantel_p", "Procrustes_M2", "PROTEST_p"]
+
+    def normalize_token(token):
+        return re.sub(r"[^a-z0-9]", "", str(token).lower())
+
+    normalized_expected = {normalize_token(col): col for col in expected_order}
+
+    def build_stats_df_from_rows(header_row, value_row):
+        stats_record = {}
+        for index, header in enumerate(header_row.tolist()):
+            header_text = str(header).strip()
+            if not header_text:
+                continue
+            normalized_header = normalize_token(header_text)
+            if normalized_header not in normalized_expected:
+                continue
+            canonical_name = normalized_expected[normalized_header]
+            value = value_row.iloc[index] if index < len(value_row) else ""
+            stats_record[canonical_name] = value
+
+        if not stats_record:
+            return pd.DataFrame(columns=expected_order)
+
+        ordered_record = {
+            col: stats_record[col] for col in expected_order if col in stats_record
+        }
+        return pd.DataFrame([ordered_record])
+
+    clean_df = df.fillna("").astype(str).apply(lambda col: col.str.strip())
+    normalized_df = clean_df.apply(
+        lambda col: col.str.lower().str.replace(r"[^a-z0-9]", "", regex=True)
+    )
+
+    empty_row_mask = clean_df.eq("").all(axis=1)
+    header_row_mask = normalized_df.isin(set(normalized_expected.keys())).any(axis=1)
+
+    separator_candidate_mask = empty_row_mask & header_row_mask.shift(-1, fill_value=False)
+    candidate_indices = np.flatnonzero(separator_candidate_mask.to_numpy())
+    valid_candidate_indices = candidate_indices[candidate_indices + 2 < len(df)]
+
+    if len(valid_candidate_indices) > 0:
+        separator_idx = int(valid_candidate_indices[0])
+        header_row = df.iloc[separator_idx + 1]
+        value_row = df.iloc[separator_idx + 2]
+        main_results_data = df.iloc[:separator_idx].copy()
+        statistical_results_data = build_stats_df_from_rows(header_row, value_row)
+        return main_results_data, statistical_results_data
+
+    return df, pd.DataFrame(columns=expected_order)
 
 
 def create_result_graphic(results_data, lang="en"):

--- a/genetic_settings_file.json
+++ b/genetic_settings_file.json
@@ -18,5 +18,5 @@
     "permutations_mantel_test": 999,
     "permutations_protest": 999,
     "mantel_test_method": "Pearson",
-    "statistical_test": "None"
+    "statistical_test": "Both"
 }

--- a/genetic_settings_file.json
+++ b/genetic_settings_file.json
@@ -18,5 +18,5 @@
     "permutations_mantel_test": 999,
     "permutations_protest": 999,
     "mantel_test_method": "Pearson",
-    "statistical_test": "Both"
+    "statistical_test": "None"
 }


### PR DESCRIPTION
This pull request refactors the results table rendering in the results page to better separate main results from statistical test results, adds support for titled tables, and improves localization and styling. The changes enhance clarity for users by displaying main results and statistical tests in distinct, clearly labeled sections, and update the code to be more robust in handling different result formats.

**Results Table Refactoring and Feature Enhancements:**

* The results page now splits output into two tables: one for main results and one for statistical test results, using the new `split_output_tables` and `create_titled_result_table` functions. This ensures statistical results are displayed separately and only if present. (`apps/pages/results/result.py`) [[1]](diffhunk://#diff-dde701abe7031050b2f78b74c35a6c1ae35964d57027987aa0d244ff9006a9c5L292-R332) [[2]](diffhunk://#diff-dde701abe7031050b2f78b74c35a6c1ae35964d57027987aa0d244ff9006a9c5R563-R645)
* The callback and layout have been updated to support the new containers for main and statistical results tables, and to handle cases where statistical results are absent. (`apps/pages/results/result.py`) [[1]](diffhunk://#diff-dde701abe7031050b2f78b74c35a6c1ae35964d57027987aa0d244ff9006a9c5L126-R127) [[2]](diffhunk://#diff-dde701abe7031050b2f78b74c35a6c1ae35964d57027987aa0d244ff9006a9c5L254-R256) [[3]](diffhunk://#diff-dde701abe7031050b2f78b74c35a6c1ae35964d57027987aa0d244ff9006a9c5L282-R284)

**Localization Improvements:**

* Added new translation keys for "Main Results" and "Statistical Tests" table titles in both English and French locale files. (`apps/locales/en/result.json`, `apps/locales/fr/result.json`) [[1]](diffhunk://#diff-d9f325b92edcf664153a52615e44c4caa04acde530e95d5118a0516b6c25608dL26-R28) [[2]](diffhunk://#diff-bbe4de57e343744e5d0b3eb0b571919ea9ce827044f9578312d2995441741d6aL26-R28)

**Styling and UI Enhancements:**

* Updated SCSS styles to add a `.results-table-title` class for table titles, and improved transition formatting for collapsible areas and tables. (`apps/assets/styles/result.scss`) [[1]](diffhunk://#diff-4a0ae92e1cdfde8df845aeabacfca78e1ee58e38d13f6f647eb568d98d7ddfc2L116-R139) [[2]](diffhunk://#diff-4a0ae92e1cdfde8df845aeabacfca78e1ee58e38d13f6f647eb568d98d7ddfc2L141-R155) [[3]](diffhunk://#diff-4a0ae92e1cdfde8df845aeabacfca78e1ee58e38d13f6f647eb568d98d7ddfc2L179-R199) [[4]](diffhunk://#diff-4a0ae92e1cdfde8df845aeabacfca78e1ee58e38d13f6f647eb568d98d7ddfc2L1-R1)
